### PR TITLE
Added threshold param to support power save mode of inverter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ As part of the device definition you need to provide the `deviceId` which is the
 according to your PV system setup. You also need to provide host and port of the device proving Solar API, which is 
 either your inverter (Fronius Galvo and Fronius Symo inverter models) or a  Fronius Datamanager.
 
+If you've configured your Fronius inverter to use power save mode, enter the threshold in watt at which power saving is activated. This helps to omit the nightly errors of the unreachable server.
+
     {
           "id": "fronius1",
           "class": "FroniusInverterRealtimeData",
@@ -35,6 +37,7 @@ either your inverter (Fronius Galvo and Fronius Symo inverter models) or a  Fron
           "host": "fronius.fritz.box",
           "port": 8001,
           "deviceId": 1
+          "threshold": 50
     }
 
 ## Contributions and Donations

--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -19,5 +19,9 @@ module.exports = {
         description: "Polling interval in seconds, value range [10-86400]"
         type: "number"
         default: 60
+      threshold:
+        description: "Threshold for PowerSaveMode of Inverter Device"
+        type: "number"
+        default: 0
   }
 }

--- a/fronius-solar.coffee
+++ b/fronius-solar.coffee
@@ -85,10 +85,9 @@ module.exports = (env) ->
           @emit "realtimeData", newError if newError isnt @_lastError
           @_lastError = newError
       ).catch((error) =>
-          newError = "Unable to get inverter realtime data from device id=" + id + ": " + error.toString()
-          @emit "realtimeData", newError if newError isnt @_lastError
-          @_lastError = newError
-
+        newError = "Unable to get inverter realtime data from device id=" + id + ": " + error.toString()
+        @emit "realtimeData", newError if newError isnt @_lastError
+        @_lastError = newError
       )
 
     _normalize: (value, lowerRange, upperRange) ->
@@ -171,7 +170,7 @@ module.exports = (env) ->
 
       @on 'realtimeData', ((error, values) ->
         if error or not values
-          if @currentPower > @threshold
+          if error and @currentPower > @threshold
             @_setAttribute 'status', i18n.__("Error")
             env.logger.error error
           else

--- a/fronius-solar.coffee
+++ b/fronius-solar.coffee
@@ -170,7 +170,7 @@ module.exports = (env) ->
 
       @on 'realtimeData', ((error, values) ->
         if error or not values
-          if error and @currentPower > @threshold
+          if error and @currentPower >= @threshold
             @_setAttribute 'status', i18n.__("Error")
             env.logger.error error
           else


### PR DESCRIPTION
Adding a threshold to the error output omits the errors in the logfile while the inverter is in power save mode. If threshold is zero, it should not affect the error handling. 
